### PR TITLE
Don't require upstream patches for boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,3 @@ Use optimistic locking to put DynamoDB records with auto-incrementing attributes
 
 - https://aws.amazon.com/blogs/aws/new-amazon-dynamodb-transactions/
 - https://bitesizedserverless.com/bite/reliable-auto-increments-in-dynamodb/
-
-## FIXME
-
-This package currently depends on code that is in a pull request for boto3 that is not yet merged or released.
-See https://github.com/boto/boto3/pull/4010.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,8 @@ classifiers = [
     "Topic :: Database",
 ]
 dependencies = [
-    "boto3 @ git+https://github.com/lpsinger/boto3@dynamodb-resource-transact-write-items",
+    "boto3",
+    "boto3-missing",
     "boto3-stubs[dynamodb]",
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
The AWS Python SDK, [boto3], has [resource] objects that provide high-level interfaces to AWS services. The [DynamoDB resource] greatly simplifies marshalling and unmarshalling data. We rely on the resource method for [TransactWriteItems] among others that are absent from boto3. We opened PR
https://github.com/boto/boto3/pull/4010 to add that method.

The resource methods are synthesized at runtime from a data file. Fortunately, boto3 has a [Loader] mechanism that allows the user to add extra data files, and the [loader search path] is configurable.

In order to not depend upon our upstream PR for boto3, we distribute the extra data files and fix up the loader search path by putting it in a [.pth file] which Python executes automatically during startup. The data and .pth file are now part of an external package, [boto3-missing].

[boto3]: https://github.com/boto/boto3
[resource]: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/resources.html
[DynamoDB resource]: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/dynamodb.html#resources
[TransactWriteItems]: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TransactWriteItems.html
[Loader]: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/loaders.html
[loader search path]: https://botocore.amazonaws.com/v1/documentation/api/latest/reference/loaders.html#the-search-path
[.pth file]: https://docs.python.org/3/library/site.html
[boto3-missing]: https://github.com/nasa-gcn/boto3-missing